### PR TITLE
Support icons and content size

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ SlidingSwitch(
  onSwipe:(){},
  textOff : "Female",
  textOn : "Male",
+ iconOff: Icons.human-female,
+ iconOn: Icons.human-male,
+ contentSize: 17,
  colorOn : const Color(0xffdc6c73),
  colorOff : const Color(0xff6682c0),
  background : const Color(0xffe4e5eb),
@@ -60,6 +63,11 @@ SlidingSwitch(
  inactiveColor : const Color(0xff636f7b),
 ),
 ```
+
+If iconOn or iconOff are not null, they will be displayed in lieu of the respective textOn and textOff.  The values for textOn and textOff are used as semantic labels for the icons for accessibility.  The icons in the example are not in the default material icon set, but are from [Material Design Icons] (https://materialdesignicons.com/), available on pub.dev [here](https://pub.dev/packages/material_design_icons_flutter).
+
+contentSize drives the height of the text or icons.
+
 Licensed Under the [MIT License](LICENSE).
 
 ## Inspiration

--- a/lib/sliding_switch.dart
+++ b/lib/sliding_switch.dart
@@ -7,6 +7,9 @@ class SlidingSwitch extends StatefulWidget {
   final bool value;
   final String textOff;
   final String textOn;
+  final IconData iconOff;
+  final IconData iconOn;
+  final double contentSize;
   final Duration animationDuration;
   final Color colorOn;
   final Color colorOff;
@@ -28,6 +31,9 @@ class SlidingSwitch extends StatefulWidget {
     this.onSwipe,
     this.textOff = "Off",
     this.textOn = "On",
+    this.iconOff,
+    this.iconOn,
+    this.contentSize = 17,
     this.colorOn = const Color(0xffdc6c73),
     this.colorOff = const Color(0xff6682c0),
     this.background = const Color(0xffe4e5eb),
@@ -114,27 +120,43 @@ class _SlidingSwitch extends State<SlidingSwitch>
               children: [
                 Expanded(
                   child: Center(
-                    child: Text(
-                      widget.textOff,
-                      style: TextStyle(
+                    child: widget.iconOff == null
+                      ? Text(
+                          widget.textOff,
+                          style: TextStyle(
+                              color: turnState
+                                  ? widget.inactiveColor
+                                  : widget.colorOff,
+                              fontSize: widget.contentSize,
+                              fontWeight: FontWeight.w600),
+                        )
+                      : Icon(widget.iconOff,
+                          semanticLabel: widget.textOff,
+                          size: widget.contentSize,
                           color: turnState
                               ? widget.inactiveColor
                               : widget.colorOff,
-                          fontSize: 17,
-                          fontWeight: FontWeight.w600),
-                    ),
+                      ),
                   ),
                 ),
                 Expanded(
                   child: Center(
-                    child: Text(
-                      widget.textOn,
-                      style: TextStyle(
-                          color:
-                              turnState ? widget.colorOn : widget.inactiveColor,
-                          fontSize: 17,
-                          fontWeight: FontWeight.w600),
-                    ),
+                    child: widget.iconOn == null
+                    ? Text(
+                        widget.textOn,
+                        style: TextStyle(
+                            color:
+                                turnState ? widget.colorOn : widget.inactiveColor,
+                            fontSize: widget.contentSize,
+                            fontWeight: FontWeight.w600),
+                      )
+                    : Icon(widget.iconOn,
+                          semanticLabel: widget.textOn,
+                          size: widget.contentSize,
+                          color: turnState
+                              ? widget.colorOn
+                              : widget.inactiveColor,
+                      ),
                   ),
                 )
               ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sliding_switch
 description:  Sliding Switch - A simple switch widget. It can be fully customized with desired width, colors, text etc. It also maintains selection state.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/CodeAppRun/sliding_switch
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sliding_switch
 description:  Sliding Switch - A simple switch widget. It can be fully customized with desired width, colors, text etc. It also maintains selection state.
-version: 0.0.4
+version: 0.1.0
 homepage: https://github.com/CodeAppRun/sliding_switch
 
 environment:


### PR DESCRIPTION
I came across this widget while working on a project.  Nice widget, clean and simple, but needed to have icons instead of text.  So here's the option to have icons instead of text.

Default icon size is also pretty big, so as long as we are controlling that, might as well control text as there is already a request in the Issues section for that feature.

I updated the readme.md to include the new parameters and a brief explanation.

Closes #1 