### PR TITLE
Allows On and Off options to be any Widget instead of just text.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -66,7 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -134,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -148,6 +155,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/lib/sliding_switch.dart
+++ b/lib/sliding_switch.dart
@@ -5,8 +5,10 @@ class SlidingSwitch extends StatefulWidget {
   final ValueChanged<bool> onChanged;
   final double width;
   final bool value;
-  final String textOff;
-  final String textOn;
+  final Widget widgetOff;
+  final Widget widgetOn;
+  final Widget? widgetOffInactive;
+  final Widget? widgetOnInactive;
   final Duration animationDuration;
   final Color colorOn;
   final Color colorOff;
@@ -26,8 +28,10 @@ class SlidingSwitch extends StatefulWidget {
     required this.onTap,
     required this.onDoubleTap,
     required this.onSwipe,
-    this.textOff = "Off",
-    this.textOn = "On",
+    this.widgetOff = const Text("Off"),
+    this.widgetOn = const Text("On"),
+    this.widgetOffInactive,
+    this.widgetOnInactive,
     this.colorOn = const Color(0xffdc6c73),
     this.colorOff = const Color(0xff6682c0),
     this.background = const Color(0xffe4e5eb),
@@ -114,28 +118,15 @@ class _SlidingSwitch extends State<SlidingSwitch>
               children: [
                 Expanded(
                   child: Center(
-                    child: Text(
-                      widget.textOff,
-                      style: TextStyle(
-                          color: turnState
-                              ? widget.inactiveColor
-                              : widget.colorOff,
-                          fontSize: 17,
-                          fontWeight: FontWeight.w600),
-                    ),
-                  ),
+                      child: turnState
+                          ? widget.widgetOffInactive ?? widget.widgetOff
+                          : widget.widgetOff),
                 ),
                 Expanded(
                   child: Center(
-                    child: Text(
-                      widget.textOn,
-                      style: TextStyle(
-                          color:
-                              turnState ? widget.colorOn : widget.inactiveColor,
-                          fontSize: 17,
-                          fontWeight: FontWeight.w600),
-                    ),
-                  ),
+                      child: turnState
+                          ? widget.widgetOn
+                          : widget.widgetOnInactive ?? widget.widgetOn),
                 )
               ],
             )

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -66,7 +66,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -127,7 +134,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:
@@ -141,6 +148,6 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
I replaced the textOff and textOn parameters with widgetOff and widgetOn parameters, as well as added the widgetOffInactive, and widgetOnInactive parameters. The slider will now display the widgetOff and widgetOn widgets in the Off and On positions respectively, with the inactive versions of the widgets displayed when they are inactive. If inactive versions are not provided, then default to the (required) widgetOff and widgetOn.